### PR TITLE
remove laminas-dependency-plugin for PHP 8.2 compatibility

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "laminas/laminas-view": "^2.11",
         "laminas/laminas-servicemanager": "^3.5",
         "laminas/laminas-eventmanager": "^3.2",
-        "smarty/smarty": "~3.1 | ^4.0",
-        "laminas/laminas-dependency-plugin": "^2.0"
+        "smarty/smarty": "~3.1 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Laminas dependency plugin is not longer supported for composer >= 2.3 versions and the module is not longer needed